### PR TITLE
Enhance and fix abilities: Magic Shield, Thunderstorm, Confection and Revolver

### DIFF
--- a/Assets/Models/GUI/Combat/ArrowUI.prefab
+++ b/Assets/Models/GUI/Combat/ArrowUI.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4905322366084376216
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8301473261680274383}
+  - component: {fileID: 1706908836835361987}
+  - component: {fileID: 8566526064161239633}
+  m_Layer: 5
+  m_Name: ArrowUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8301473261680274383
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4905322366084376216}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1706908836835361987
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4905322366084376216}
+  m_CullTransparentMesh: 1
+--- !u!114 &8566526064161239633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4905322366084376216}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4009434, g: 0.6832626, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c8e28b5e5689d0f4382ba5f6416d8675, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Models/GUI/Combat/ArrowUI.prefab
+++ b/Assets/Models/GUI/Combat/ArrowUI.prefab
@@ -58,7 +58,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.4009434, g: 0.6832626, b: 1, a: 1}
+  m_Color: {r: 0, g: 0.5, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Models/GUI/Combat/ArrowUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/ArrowUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9eef64837d1e03a4cbb0a90c0eacdf10
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/BrocolliUI.prefab
+++ b/Assets/Models/GUI/Combat/BrocolliUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8761894498351811927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8761894498351811928}
+  - component: {fileID: 8761894498351811932}
+  - component: {fileID: 8761894498351811931}
+  - component: {fileID: 8761894498351811930}
+  - component: {fileID: 8761894498351811929}
+  m_Layer: 5
+  m_Name: BrocolliUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8761894498351811928
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8761894498351811927}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 143.88983, y: -26.910074}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8761894498351811932
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8761894498351811927}
+  m_CullTransparentMesh: 0
+--- !u!114 &8761894498351811931
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8761894498351811927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 463af5dda0a27f8418bec404080d6ac4, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8761894498351811930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8761894498351811927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &8761894498351811929
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8761894498351811927}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/BrocolliUI.prefab
+++ b/Assets/Models/GUI/Combat/BrocolliUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 3
 --- !u!225 &8761894498351811929
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/BrocolliUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/BrocolliUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0fb2e63135ad0f4fbea5877b66a7761
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/Bullet.prefab
+++ b/Assets/Models/GUI/Combat/Bullet.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 1
 --- !u!225 &8360622346803862843
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/ChocolateUI.prefab
+++ b/Assets/Models/GUI/Combat/ChocolateUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1407240184101039587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1407240184101039588}
+  - component: {fileID: 1407240184101039592}
+  - component: {fileID: 1407240184101039591}
+  - component: {fileID: 1407240184101039590}
+  - component: {fileID: 1407240184101039589}
+  m_Layer: 5
+  m_Name: ChocolateUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1407240184101039588
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407240184101039587}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -110.810196, y: 59.39995}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1407240184101039592
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407240184101039587}
+  m_CullTransparentMesh: 0
+--- !u!114 &1407240184101039591
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407240184101039587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 748d019dc310c564c923afc631fd3ff6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1407240184101039590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407240184101039587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &1407240184101039589
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1407240184101039587}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/ChocolateUI.prefab
+++ b/Assets/Models/GUI/Combat/ChocolateUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 2
 --- !u!225 &1407240184101039589
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/ChocolateUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/ChocolateUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c6b980767e5d4843927c7dd4c13fb62
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/MushroomUI.prefab
+++ b/Assets/Models/GUI/Combat/MushroomUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5175591515052858200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5175591515052858201}
+  - component: {fileID: 5175591515052858205}
+  - component: {fileID: 5175591515052858204}
+  - component: {fileID: 5175591515052858207}
+  - component: {fileID: 5175591515052858206}
+  m_Layer: 5
+  m_Name: MushroomUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5175591515052858201
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5175591515052858200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -136.58022, y: -13.400063}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5175591515052858205
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5175591515052858200}
+  m_CullTransparentMesh: 0
+--- !u!114 &5175591515052858204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5175591515052858200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: f089953fd8c62b04ab3d38bd5d449494, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5175591515052858207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5175591515052858200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &5175591515052858206
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5175591515052858200}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/MushroomUI.prefab
+++ b/Assets/Models/GUI/Combat/MushroomUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 3
 --- !u!225 &5175591515052858206
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/MushroomUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/MushroomUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2c7f04adb1481144c937479808b97e9a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/StrawberryUI.prefab
+++ b/Assets/Models/GUI/Combat/StrawberryUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4885552983801235782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4885552983801235785}
+  - component: {fileID: 4885552983801235789}
+  - component: {fileID: 4885552983801235786}
+  - component: {fileID: 4885552983801235787}
+  - component: {fileID: 4885552983801235784}
+  m_Layer: 5
+  m_Name: StrawberryUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4885552983801235785
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4885552983801235782}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 139, y: 37}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4885552983801235789
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4885552983801235782}
+  m_CullTransparentMesh: 0
+--- !u!114 &4885552983801235786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4885552983801235782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 7fde758bb387ed14b8400c59c683110e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4885552983801235787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4885552983801235782}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &4885552983801235784
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4885552983801235782}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/StrawberryUI.prefab
+++ b/Assets/Models/GUI/Combat/StrawberryUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 2
 --- !u!225 &4885552983801235784
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/StrawberryUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/StrawberryUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ef49b7fac1c178488ee7028223a7ef2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/SugarUI.prefab
+++ b/Assets/Models/GUI/Combat/SugarUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 2
 --- !u!225 &3964241220478960269
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/SugarUI.prefab
+++ b/Assets/Models/GUI/Combat/SugarUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3964241220478960271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3964241220478960268}
+  - component: {fileID: 3964241220478960264}
+  - component: {fileID: 3964241220478960267}
+  - component: {fileID: 3964241220478960266}
+  - component: {fileID: 3964241220478960269}
+  m_Layer: 5
+  m_Name: SugarUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3964241220478960268
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3964241220478960271}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 21.889805, y: 93.79995}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3964241220478960264
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3964241220478960271}
+  m_CullTransparentMesh: 0
+--- !u!114 &3964241220478960267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3964241220478960271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: abd306aeeb2203b409be2181f329b419, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3964241220478960266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3964241220478960271}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &3964241220478960269
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3964241220478960271}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/SugarUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/SugarUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de584728bf140ce4e91afab68de87bf3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/SushiUI.prefab
+++ b/Assets/Models/GUI/Combat/SushiUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 3
 --- !u!225 &5952850310990763031
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/SushiUI.prefab
+++ b/Assets/Models/GUI/Combat/SushiUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5952850310990763029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5952850310990763030}
+  - component: {fileID: 5952850310990763114}
+  - component: {fileID: 5952850310990763113}
+  - component: {fileID: 5952850310990763112}
+  - component: {fileID: 5952850310990763031}
+  m_Layer: 5
+  m_Name: SushiUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5952850310990763030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5952850310990763029}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 93.99981, y: 93.39996}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5952850310990763114
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5952850310990763029}
+  m_CullTransparentMesh: 0
+--- !u!114 &5952850310990763113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5952850310990763029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 6a8386bc7d66fc24091735b107de5471, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5952850310990763112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5952850310990763029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &5952850310990763031
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5952850310990763029}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/SushiUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/SushiUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3afe4d1fd94845d4eb05212b545ef2e3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/GUI/Combat/SweetUI.prefab
+++ b/Assets/Models/GUI/Combat/SweetUI.prefab
@@ -1,0 +1,103 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5817660897569141627
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5817660897569141626}
+  - component: {fileID: 5817660897569141630}
+  - component: {fileID: 5817660897569141631}
+  - component: {fileID: 5817660897569141624}
+  - component: {fileID: 5817660897569141625}
+  m_Layer: 5
+  m_Name: SweetUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5817660897569141626
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817660897569141627}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -47.222168, y: 95.29995}
+  m_SizeDelta: {x: 45, y: 45}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5817660897569141630
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817660897569141627}
+  m_CullTransparentMesh: 0
+--- !u!114 &5817660897569141631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817660897569141627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ded5b3e99a28c1744bcd1eac02fbb0fe, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5817660897569141624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817660897569141627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &5817660897569141625
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5817660897569141627}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1

--- a/Assets/Models/GUI/Combat/SweetUI.prefab
+++ b/Assets/Models/GUI/Combat/SweetUI.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DropTypeEnum: 2
 --- !u!225 &5817660897569141625
 CanvasGroup:
   m_ObjectHideFlags: 0

--- a/Assets/Models/GUI/Combat/SweetUI.prefab.meta
+++ b/Assets/Models/GUI/Combat/SweetUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 869802038bbca6a43a497f898e64dc21
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Costumes/Abilities/Lightning.prefab
+++ b/Assets/Prefabs/Costumes/Abilities/Lightning.prefab
@@ -4990,8 +4990,8 @@ ParticleSystem:
     startLifetime:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 0.1
-      minScalar: 0.05
+      scalar: 0.2
+      minScalar: 0.1
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -5535,7 +5535,7 @@ ParticleSystem:
     serializedVersion: 6
     enabled: 1
     type: 4
-    angle: 5.41
+    angle: 16
     length: 5
     boxThickness: {x: 0, y: 0, z: 0}
     radiusThickness: 1
@@ -5621,7 +5621,7 @@ ParticleSystem:
     sphericalDirectionAmount: 0
     randomPositionAmount: 0
     radius:
-      value: 0.3
+      value: 5
       mode: 0
       spread: 0
       speed:
@@ -5740,7 +5740,7 @@ ParticleSystem:
     rateOverTime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 100
+      scalar: 300
       minScalar: 10
       maxCurve:
         serializedVersion: 2

--- a/Assets/Prefabs/Costumes/Abilities/Thunderstorm.prefab
+++ b/Assets/Prefabs/Costumes/Abilities/Thunderstorm.prefab
@@ -40,7 +40,7 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1677016244845615128}
-  serializedVersion: 6
+  serializedVersion: 7
   lengthInSec: 1
   simulationSpeed: 1
   stopAction: 0
@@ -222,8 +222,8 @@ ParticleSystem:
     startColor:
       serializedVersion: 2
       minMaxState: 2
-      minColor: {r: 0.122641504, g: 0.122641504, b: 0.122641504, a: 1}
-      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      minColor: {r: 0.08966714, g: 0.102345034, b: 0.122641504, a: 1}
+      maxColor: {r: 0.53017086, g: 0.611032, b: 0.6981132, a: 1}
       maxGradient:
         serializedVersion: 2
         key0: {r: 1, g: 1, b: 1, a: 1}
@@ -601,7 +601,7 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
-    maxNumParticles: 1500
+    maxNumParticles: 3000
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -747,7 +747,7 @@ ParticleSystem:
     sphericalDirectionAmount: 0
     randomPositionAmount: 0
     radius:
-      value: 36.7
+      value: 50
       mode: 0
       spread: 0
       speed:
@@ -866,7 +866,7 @@ ParticleSystem:
     rateOverTime:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 500
+      scalar: 1000
       minScalar: 10
       maxCurve:
         serializedVersion: 2
@@ -1304,9 +1304,9 @@ ParticleSystem:
       maxColor: {r: 1, g: 1, b: 1, a: 1}
       maxGradient:
         serializedVersion: 2
-        key0: {r: 1, g: 1, b: 1, a: 0.08627451}
+        key0: {r: 0.7971698, g: 0.8973349, b: 1, a: 0.08627451}
         key1: {r: 1, g: 1, b: 1, a: 0.0627451}
-        key2: {r: 1, g: 1, b: 1, a: 0}
+        key2: {r: 0.79607844, g: 0.8980392, b: 1, a: 0}
         key3: {r: 1, g: 1, b: 1, a: 0}
         key4: {r: 1, g: 1, b: 1, a: 0}
         key5: {r: 0, g: 0, b: 0, a: 0}
@@ -1314,13 +1314,13 @@ ParticleSystem:
         key7: {r: 0, g: 0, b: 0, a: 0}
         ctime0: 0
         ctime1: 31804
-        ctime2: 65535
+        ctime2: 65150
         ctime3: 65535
         ctime4: 65535
         ctime5: 0
         ctime6: 0
         ctime7: 0
-        atime0: 964
+        atime0: 1542
         atime1: 7517
         atime2: 65535
         atime3: 0
@@ -3613,19 +3613,20 @@ ParticleSystem:
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -3799,17 +3800,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -4856,15 +4860,15 @@ ParticleSystemForceField:
   m_Parameters:
     m_Shape: 0
     m_StartRange: 0
-    m_EndRange: 35
+    m_EndRange: 100
     m_Length: 1
     m_GravityFocus: 0
-    m_RotationRandomness: {x: 0, y: 0}
+    m_RotationRandomness: {x: 1, y: 1}
     m_DirectionCurveX:
       serializedVersion: 2
-      minMaxState: 0
-      scalar: 0
-      minScalar: 0
+      minMaxState: 3
+      scalar: 10
+      minScalar: -10
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -4917,7 +4921,7 @@ ParticleSystemForceField:
       serializedVersion: 2
       minMaxState: 3
       scalar: 5
-      minScalar: -5
+      minScalar: -15
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -4968,9 +4972,9 @@ ParticleSystemForceField:
         m_RotationOrder: 4
     m_DirectionCurveZ:
       serializedVersion: 2
-      minMaxState: 0
-      scalar: 0
-      minScalar: 0
+      minMaxState: 3
+      scalar: 10
+      minScalar: -10
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -5022,7 +5026,7 @@ ParticleSystemForceField:
     m_GravityCurve:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 0.12
+      scalar: 0.07
       minScalar: 1
       maxCurve:
         serializedVersion: 2
@@ -5075,8 +5079,8 @@ ParticleSystemForceField:
     m_RotationSpeedCurve:
       serializedVersion: 2
       minMaxState: 3
-      scalar: 1.6
-      minScalar: 0.8
+      scalar: 1
+      minScalar: -1
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -5181,7 +5185,7 @@ ParticleSystemForceField:
     m_DragCurve:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 0
+      scalar: 0.01
       minScalar: 0
       maxCurve:
         serializedVersion: 2

--- a/Assets/Prefabs/UI/Ganiel's UI.prefab
+++ b/Assets/Prefabs/UI/Ganiel's UI.prefab
@@ -1,5 +1,40 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &32015637468423594
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4917653963586160251}
+  m_Layer: 5
+  m_Name: IngredientSpawner (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4917653963586160251
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 32015637468423594}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 68.6, y: 77}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &731468134708096655
 GameObject:
   m_ObjectHideFlags: 0
@@ -136,6 +171,18 @@ RectTransform:
   m_AnchoredPosition: {x: -168.6, y: -1.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &312707653974936036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1068815459606876822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1181963720811853941
 GameObject:
   m_ObjectHideFlags: 0
@@ -170,6 +217,41 @@ Transform:
   m_Father: {fileID: 2902132781938477778}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1297265046394155879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7898608001803798589}
+  m_Layer: 5
+  m_Name: IngredientSpawner (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7898608001803798589
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1297265046394155879}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -96.5, y: -29.4}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1333034268797288950
 GameObject:
   m_ObjectHideFlags: 0
@@ -203,6 +285,41 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 143.8, y: 95.7}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1531111683539428302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2861300414826752395}
+  m_Layer: 5
+  m_Name: IngredientSpawner (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2861300414826752395
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1531111683539428302}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -127.5, y: 22.6}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1577401503725109089
@@ -240,6 +357,18 @@ RectTransform:
   m_AnchoredPosition: {x: -168.2, y: 97.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5638182524287243577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1908135428853529909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2036920177417858245
 GameObject:
   m_ObjectHideFlags: 0
@@ -411,6 +540,41 @@ RectTransform:
   m_AnchoredPosition: {x: 144.9, y: 16.6}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2725620080624364059
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2480484824646191679}
+  m_Layer: 5
+  m_Name: IngredientSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2480484824646191679
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2725620080624364059}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -139.6, y: 110.8}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2751598225131616083
 GameObject:
   m_ObjectHideFlags: 0
@@ -479,6 +643,41 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 112.7, y: 41.4}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2831729533487336412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4614577324672544047}
+  m_Layer: 5
+  m_Name: IngredientSpawner (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4614577324672544047
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2831729533487336412}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 20
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 110.1, y: -88.1}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2915266068502790727
@@ -661,6 +860,41 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 0
+--- !u!1 &3390780154999267369
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4716224448750590100}
+  m_Layer: 5
+  m_Name: IngredientSpawner (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4716224448750590100
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3390780154999267369}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -74.7, y: 77.7}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3620217108836286719
 GameObject:
   m_ObjectHideFlags: 0
@@ -736,6 +970,53 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8120449923393061863
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3629783549193465900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &3753020584209137767
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7777099977188230668}
+  m_Layer: 5
+  m_Name: IngredientSpawner (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7777099977188230668
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3753020584209137767}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -131.2, y: -81.4}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3830455676991063419
 GameObject:
   m_ObjectHideFlags: 0
@@ -829,6 +1110,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &4123598207942443794
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -858,6 +1140,18 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &4720230919927986880
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3919868333965691841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4120477273441607620
 GameObject:
   m_ObjectHideFlags: 0
@@ -1135,6 +1429,18 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &1571187947173443497
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825868979387892557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4878168431363649351
 GameObject:
   m_ObjectHideFlags: 0
@@ -1305,6 +1611,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1563,6 +1870,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &3544751799100529244
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1624,107 +1932,6 @@ Transform:
   m_Father: {fileID: 4805335919054704252}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5650117168264658493
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117168264658490}
-  - component: {fileID: 5650117168264658486}
-  - component: {fileID: 5650117168264658489}
-  - component: {fileID: 5650117168264658488}
-  - component: {fileID: 5650117168264658491}
-  m_Layer: 5
-  m_Name: Sweet
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117168264658490
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168264658493}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -110.810196, y: 59.39995}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117168264658486
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168264658493}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117168264658489
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168264658493}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 748d019dc310c564c923afc631fd3ff6, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117168264658488
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168264658493}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117168264658491
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168264658493}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
 --- !u!1 &5650117168553605586
 GameObject:
   m_ObjectHideFlags: 0
@@ -1800,107 +2007,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &5650117168762644828
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117168762644829}
-  - component: {fileID: 5650117168762644825}
-  - component: {fileID: 5650117168762644824}
-  - component: {fileID: 5650117168762644827}
-  - component: {fileID: 5650117168762644826}
-  m_Layer: 5
-  m_Name: Rotten
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117168762644829
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168762644828}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -136.58022, y: -13.400063}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117168762644825
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168762644828}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117168762644824
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168762644828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: f089953fd8c62b04ab3d38bd5d449494, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117168762644827
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168762644828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117168762644826
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168762644828}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
 --- !u!1 &5650117168781819745
 GameObject:
   m_ObjectHideFlags: 0
@@ -1931,7 +2037,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 9
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -2428,107 +2534,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &5650117168964495555
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117168964495552}
-  - component: {fileID: 5650117168964495548}
-  - component: {fileID: 5650117168964495551}
-  - component: {fileID: 5650117168964495550}
-  - component: {fileID: 5650117168964495553}
-  m_Layer: 5
-  m_Name: Rotten
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117168964495552
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168964495555}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 93.99981, y: 93.39996}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117168964495548
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168964495555}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117168964495551
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168964495555}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6a8386bc7d66fc24091735b107de5471, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117168964495550
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168964495555}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117168964495553
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117168964495555}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
 --- !u!1 &5650117168966652993
 GameObject:
   m_ObjectHideFlags: 0
@@ -2619,6 +2624,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &5650117168966652988
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2883,14 +2889,26 @@ RectTransform:
   m_Children:
   - {fileID: 5650117169156364522}
   - {fileID: 5650117169704977413}
-  - {fileID: 5650117169898459167}
-  - {fileID: 5650117170239476022}
-  - {fileID: 5650117168264658490}
-  - {fileID: 5650117169958220244}
-  - {fileID: 5650117168964495552}
-  - {fileID: 5650117170005917510}
-  - {fileID: 5650117168762644829}
   - {fileID: 5650117168781819742}
+  - {fileID: 3919868333965691854}
+  - {fileID: 1068815459606876817}
+  - {fileID: 8739912033568406619}
+  - {fileID: 4825868979387892546}
+  - {fileID: 3629783549193465903}
+  - {fileID: 8005502527238466081}
+  - {fileID: 1908135428853529908}
+  - {fileID: 2480484824646191679}
+  - {fileID: 4716224448750590100}
+  - {fileID: 3624136284522428375}
+  - {fileID: 4834426053173541543}
+  - {fileID: 4917653963586160251}
+  - {fileID: 1600612634735457801}
+  - {fileID: 7962404806484106671}
+  - {fileID: 2861300414826752395}
+  - {fileID: 7898608001803798589}
+  - {fileID: 7777099977188230668}
+  - {fileID: 4614577324672544047}
+  - {fileID: 3077555402441148513}
   m_Father: {fileID: 5650117169937024852}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2942,6 +2960,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &5650117169178652663
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3840,6 +3859,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -3900,107 +3920,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!1 &5650117169898459166
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117169898459167}
-  - component: {fileID: 5650117169898459163}
-  - component: {fileID: 5650117169898459162}
-  - component: {fileID: 5650117169898459165}
-  - component: {fileID: 5650117169898459164}
-  m_Layer: 5
-  m_Name: Sweet
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117169898459167
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169898459166}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -47.222168, y: 95.29995}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117169898459163
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169898459166}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117169898459162
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169898459166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: ded5b3e99a28c1744bcd1eac02fbb0fe, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117169898459165
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169898459166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117169898459164
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169898459166}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
 --- !u!1 &5650117169937024855
 GameObject:
   m_ObjectHideFlags: 0
@@ -4033,208 +3952,6 @@ Transform:
   m_Father: {fileID: 4805335919054704252}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5650117169958220247
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117169958220244}
-  - component: {fileID: 5650117169958220240}
-  - component: {fileID: 5650117169958220243}
-  - component: {fileID: 5650117169958220242}
-  - component: {fileID: 5650117169958220245}
-  m_Layer: 5
-  m_Name: Sweet
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117169958220244
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169958220247}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 21.889805, y: 93.79995}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117169958220240
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169958220247}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117169958220243
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169958220247}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: abd306aeeb2203b409be2181f329b419, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117169958220242
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169958220247}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117169958220245
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117169958220247}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
---- !u!1 &5650117170005917513
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117170005917510}
-  - component: {fileID: 5650117170005917506}
-  - component: {fileID: 5650117170005917509}
-  - component: {fileID: 5650117170005917508}
-  - component: {fileID: 5650117170005917511}
-  m_Layer: 5
-  m_Name: Rotten
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117170005917510
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170005917513}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 143.88983, y: -26.910074}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117170005917506
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170005917513}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117170005917509
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170005917513}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 463af5dda0a27f8418bec404080d6ac4, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117170005917508
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170005917513}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117170005917511
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170005917513}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
 --- !u!1 &5650117170068254125
 GameObject:
   m_ObjectHideFlags: 0
@@ -4326,6 +4043,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -4510,107 +4228,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!1 &5650117170239476025
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5650117170239476022}
-  - component: {fileID: 5650117170239476018}
-  - component: {fileID: 5650117170239476021}
-  - component: {fileID: 5650117170239476020}
-  - component: {fileID: 5650117170239476023}
-  m_Layer: 5
-  m_Name: Sweet
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5650117170239476022
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170239476025}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 139, y: 37}
-  m_SizeDelta: {x: 45, y: 45}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5650117170239476018
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170239476025}
-  m_CullTransparentMesh: 0
---- !u!114 &5650117170239476021
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170239476025}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 7fde758bb387ed14b8400c59c683110e, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5650117170239476020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170239476025}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &5650117170239476023
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5650117170239476025}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 1
 --- !u!1 &5650117170248726543
 GameObject:
   m_ObjectHideFlags: 0
@@ -4688,6 +4305,41 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5744601557947030412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3624136284522428375}
+  m_Layer: 5
+  m_Name: IngredientSpawner (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3624136284522428375
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5744601557947030412}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -4.6, y: 113.2}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5823209008936102448
 GameObject:
   m_ObjectHideFlags: 0
@@ -4723,6 +4375,41 @@ RectTransform:
   m_AnchoredPosition: {x: 122.6, y: -44.1}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5929867499229330490
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3077555402441148513}
+  m_Layer: 5
+  m_Name: IngredientSpawner (11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3077555402441148513
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5929867499229330490}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 21
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -49.8, y: -104}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6256426769337162877
 GameObject:
   m_ObjectHideFlags: 0
@@ -4756,6 +4443,76 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -132.7, y: -49.4}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6368295264227912360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1600612634735457801}
+  m_Layer: 5
+  m_Name: IngredientSpawner (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1600612634735457801
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6368295264227912360}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 150.8, y: 92.1}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6808847620924505044
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4834426053173541543}
+  m_Layer: 5
+  m_Name: IngredientSpawner (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4834426053173541543
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6808847620924505044}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 111.6, y: 13.7}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6809638092553659792
@@ -5121,6 +4878,53 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AbilityDescription: {fileID: 11400000, guid: 432e496dc147c8f4baeb0d7db3347280, type: 2}
   AbilityDescriptionPanel: {fileID: 5650117170248726543}
+--- !u!114 &1647763789516619170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8005502527238466082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &8026136126972687431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7962404806484106671}
+  m_Layer: 5
+  m_Name: IngredientSpawner (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7962404806484106671
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8026136126972687431}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5650117169178652661}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 156.9, y: -32.3}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8096251245933062271
 GameObject:
   m_ObjectHideFlags: 0
@@ -5299,6 +5103,18 @@ RectTransform:
   m_AnchoredPosition: {x: 117.3, y: -63.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1548660382456300412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8739912033568406618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8794592386017682959
 GameObject:
   m_ObjectHideFlags: 0
@@ -5549,6 +5365,113 @@ MonoBehaviour:
   DropClipSource: {fileID: 0}
   BulletEmpty: {fileID: 21300000, guid: 144eb6db9cb34924ab8c284d51e4d3d8, type: 3}
   BulletFilled: {fileID: 21300000, guid: 9e6b5d5ee5bd66045870a3e980036174, type: 3}
+--- !u!1001 &86719347420858891
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 4885552983801235782, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_Name
+      value: StrawberryUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 45.373413
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100.000626
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+--- !u!1 &4825868979387892557 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4885552983801235782, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+  m_PrefabInstance: {fileID: 86719347420858891}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &4825868979387892546 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
+  m_PrefabInstance: {fileID: 86719347420858891}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &355252574903612033
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5556,6 +5479,42 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2902132781938477778}
     m_Modifications:
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -5567,6 +5526,10 @@ PrefabInstance:
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
       propertyPath: m_LocalRotation.x
@@ -5581,12 +5544,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 138.3
       objectReference: {fileID: 0}
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_RootOrder
-      value: 5
+      propertyPath: m_AnchoredPosition.y
+      value: 101.3
       objectReference: {fileID: 0}
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5599,46 +5562,6 @@ PrefabInstance:
     - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 138.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 101.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6902293624259866740, guid: b235ccd6820c1214592629644f9dd823, type: 3}
       propertyPath: m_Name
@@ -5651,6 +5574,113 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6207258437989208674, guid: b235ccd6820c1214592629644f9dd823, type: 3}
   m_PrefabInstance: {fileID: 355252574903612033}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &386259031362613923
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 115.32507
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 63.15297
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3964241220478960271, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+      propertyPath: m_Name
+      value: SugarUI
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+--- !u!224 &3629783549193465903 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+  m_PrefabInstance: {fileID: 386259031362613923}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3629783549193465900 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3964241220478960271, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
+  m_PrefabInstance: {fileID: 386259031362613923}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1706949703475846884
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5658,6 +5688,42 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 7730453772010055890}
     m_Modifications:
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -5669,6 +5735,10 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalRotation.x
@@ -5683,12 +5753,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5701,46 +5771,6 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -25
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 22.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 45
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7721879864927319573, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_Name
@@ -5765,6 +5795,42 @@ PrefabInstance:
       value: Cloud (2)
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5775,6 +5841,10 @@ PrefabInstance:
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalRotation.x
@@ -5789,12 +5859,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
+      propertyPath: m_AnchoredPosition.y
+      value: 105.4
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5808,52 +5878,119 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 105.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
 --- !u!224 &9176264921436648165 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
   m_PrefabInstance: {fileID: 1770439543467597214}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2112949648828088181
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 1407240184101039587, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_Name
+      value: ChocolateUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -109.84363
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 56.090714
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+--- !u!1 &1068815459606876822 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1407240184101039587, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+  m_PrefabInstance: {fileID: 2112949648828088181}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1068815459606876817 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
+  m_PrefabInstance: {fileID: 2112949648828088181}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2769973262506789499
 PrefabInstance:
@@ -5867,6 +6004,42 @@ PrefabInstance:
       value: Cloud (1)
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5877,6 +6050,10 @@ PrefabInstance:
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalRotation.x
@@ -5891,12 +6068,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: -145
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
+      propertyPath: m_AnchoredPosition.y
+      value: 115.1
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -5909,46 +6086,6 @@ PrefabInstance:
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -145
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 115.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
@@ -5965,6 +6102,42 @@ PrefabInstance:
     m_TransformParent: {fileID: 7730453772010055890}
     m_Modifications:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5975,6 +6148,10 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalRotation.x
@@ -5989,12 +6166,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: -20
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
+      propertyPath: m_AnchoredPosition.y
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6007,46 +6184,6 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -20
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -25
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 22.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 45
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7721879864927319573, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_Name
@@ -6071,6 +6208,42 @@ PrefabInstance:
       value: Cloud
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -6081,6 +6254,10 @@ PrefabInstance:
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6095,12 +6272,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 122
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
+      propertyPath: m_AnchoredPosition.y
+      value: 92.2
       objectReference: {fileID: 0}
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6113,46 +6290,6 @@ PrefabInstance:
     - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 122
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 92.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7478641909929029499, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 901f9479ac1961a449004962b6fa9bb7, type: 3}
@@ -6169,6 +6306,42 @@ PrefabInstance:
     m_TransformParent: {fileID: 7730453772010055890}
     m_Modifications:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -6179,6 +6352,10 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6193,12 +6370,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
+      propertyPath: m_AnchoredPosition.y
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6211,46 +6388,6 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -25
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 22.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 45
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7721879864927319573, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_Name
@@ -6271,6 +6408,42 @@ PrefabInstance:
     m_TransformParent: {fileID: 4529550150709540511}
     m_Modifications:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -6281,6 +6454,10 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6295,12 +6472,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: -317
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: -23
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6313,46 +6490,6 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -317
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -23
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 3011966494365126380, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_Name
@@ -6373,6 +6510,220 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
   m_PrefabInstance: {fileID: 4030206714711499660}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4433098887223836215
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 5952850310990763029, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_Name
+      value: SushiUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 141.48035
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 7.830948
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+--- !u!224 &8005502527238466081 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+  m_PrefabInstance: {fileID: 4433098887223836215}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8005502527238466082 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5952850310990763029, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
+  m_PrefabInstance: {fileID: 4433098887223836215}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4510639525382448898
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 5175591515052858200, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_Name
+      value: MushroomUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -40.73828
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 103.74608
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+--- !u!1 &8739912033568406618 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5175591515052858200, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+  m_PrefabInstance: {fileID: 4510639525382448898}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8739912033568406619 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
+  m_PrefabInstance: {fileID: 4510639525382448898}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4763275179647895846
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6380,6 +6731,42 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 7730453772010055890}
     m_Modifications:
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -6391,6 +6778,10 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6405,12 +6796,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6423,46 +6814,6 @@ PrefabInstance:
     - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -25
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 22.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 45
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7721879864927319573, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
       propertyPath: m_Name
@@ -6475,6 +6826,113 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5966408295431876837, guid: deda058a990ca114d8ba9f8b975e1c35, type: 3}
   m_PrefabInstance: {fileID: 4763275179647895846}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5388403929890360910
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 113.861694
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -70.55404
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5817660897569141627, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+      propertyPath: m_Name
+      value: SweetUI
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+--- !u!1 &1908135428853529909 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5817660897569141627, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+  m_PrefabInstance: {fileID: 5388403929890360910}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1908135428853529908 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
+  m_PrefabInstance: {fileID: 5388403929890360910}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5445159148127031446
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6482,6 +6940,42 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4529550150709540511}
     m_Modifications:
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -6493,6 +6987,10 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6507,12 +7005,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 254
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
+      propertyPath: m_AnchoredPosition.y
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6525,46 +7023,6 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 254
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 39
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 3011966494365126380, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_Name
@@ -6601,6 +7059,10 @@ PrefabInstance:
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
       propertyPath: m_LocalPosition.x
       value: 497.65906
       objectReference: {fileID: 0}
@@ -6613,6 +7075,10 @@ PrefabInstance:
       value: 551.3651
       objectReference: {fileID: 0}
     - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -6623,14 +7089,6 @@ PrefabInstance:
     - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
-      propertyPath: m_RootOrder
-      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6651,6 +7109,113 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8983732888929752668, guid: 985e628de08fb6443ad13a330d2b83e5, type: 3}
   m_PrefabInstance: {fileID: 5744943425817925016}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5764233571269494422
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5650117169178652661}
+    m_Modifications:
+    - target: {fileID: 8761894498351811927, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_Name
+      value: BrocolliUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -132.13824
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -20.054039
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+--- !u!1 &3919868333965691841 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8761894498351811927, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+  m_PrefabInstance: {fileID: 5764233571269494422}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &3919868333965691854 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
+  m_PrefabInstance: {fileID: 5764233571269494422}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5800703235530589926
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6658,6 +7223,42 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4529550150709540511}
     m_Modifications:
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -6669,6 +7270,10 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6683,12 +7288,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 112
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 179
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6701,46 +7306,6 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 112
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 179
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 3011966494365126380, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_Name
@@ -6769,6 +7334,42 @@ PrefabInstance:
     m_TransformParent: {fileID: 4529550150709540511}
     m_Modifications:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -6779,6 +7380,10 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalRotation.x
@@ -6793,12 +7398,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: -369
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
+      propertyPath: m_AnchoredPosition.y
+      value: 159
       objectReference: {fileID: 0}
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -6811,46 +7416,6 @@ PrefabInstance:
     - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -369
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 159
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 35202260235722621, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 3011966494365126380, guid: 7e3ba5127d08a414fb3b774b7eee98cd, type: 3}
       propertyPath: m_Name

--- a/Assets/Prefabs/UI/Ganiel's UI.prefab
+++ b/Assets/Prefabs/UI/Ganiel's UI.prefab
@@ -28,7 +28,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 14
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -171,18 +171,6 @@ RectTransform:
   m_AnchoredPosition: {x: -168.6, y: -1.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &312707653974936036
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1068815459606876822}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1181963720811853941
 GameObject:
   m_ObjectHideFlags: 0
@@ -245,7 +233,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 18
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -315,7 +303,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 17
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -357,18 +345,6 @@ RectTransform:
   m_AnchoredPosition: {x: -168.2, y: 97.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &5638182524287243577
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1908135428853529909}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2036920177417858245
 GameObject:
   m_ObjectHideFlags: 0
@@ -568,7 +544,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 10
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -673,7 +649,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 20
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -888,7 +864,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 11
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -970,18 +946,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &8120449923393061863
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3629783549193465900}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &3753020584209137767
 GameObject:
   m_ObjectHideFlags: 0
@@ -1010,7 +974,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 19
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1140,18 +1104,6 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!114 &4720230919927986880
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3919868333965691841}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &4120477273441607620
 GameObject:
   m_ObjectHideFlags: 0
@@ -1429,18 +1381,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!114 &1571187947173443497
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4825868979387892557}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &4878168431363649351
 GameObject:
   m_ObjectHideFlags: 0
@@ -2037,7 +1977,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 2
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -2889,14 +2829,6 @@ RectTransform:
   m_Children:
   - {fileID: 5650117169156364522}
   - {fileID: 5650117169704977413}
-  - {fileID: 5650117168781819742}
-  - {fileID: 3919868333965691854}
-  - {fileID: 1068815459606876817}
-  - {fileID: 8739912033568406619}
-  - {fileID: 4825868979387892546}
-  - {fileID: 3629783549193465903}
-  - {fileID: 8005502527238466081}
-  - {fileID: 1908135428853529908}
   - {fileID: 2480484824646191679}
   - {fileID: 4716224448750590100}
   - {fileID: 3624136284522428375}
@@ -2909,6 +2841,14 @@ RectTransform:
   - {fileID: 7777099977188230668}
   - {fileID: 4614577324672544047}
   - {fileID: 3077555402441148513}
+  - {fileID: 3919868333965691854}
+  - {fileID: 1068815459606876817}
+  - {fileID: 8739912033568406619}
+  - {fileID: 4825868979387892546}
+  - {fileID: 3629783549193465903}
+  - {fileID: 8005502527238466081}
+  - {fileID: 1908135428853529908}
+  - {fileID: 5650117168781819742}
   m_Father: {fileID: 5650117169937024852}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4333,7 +4273,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 12
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4403,7 +4343,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 21
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4473,7 +4413,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 15
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4508,7 +4448,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 13
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4878,18 +4818,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   AbilityDescription: {fileID: 11400000, guid: 432e496dc147c8f4baeb0d7db3347280, type: 2}
   AbilityDescriptionPanel: {fileID: 5650117170248726543}
---- !u!114 &1647763789516619170
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8005502527238466082}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &8026136126972687431
 GameObject:
   m_ObjectHideFlags: 0
@@ -4918,7 +4846,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5650117169178652661}
-  m_RootOrder: 16
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5103,18 +5031,6 @@ RectTransform:
   m_AnchoredPosition: {x: 117.3, y: -63.3}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1548660382456300412
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8739912033568406618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &8794592386017682959
 GameObject:
   m_ObjectHideFlags: 0
@@ -5386,7 +5302,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5462,11 +5378,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
---- !u!1 &4825868979387892557 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4885552983801235782, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
-  m_PrefabInstance: {fileID: 86719347420858891}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &4825868979387892546 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 4885552983801235785, guid: 9ef49b7fac1c178488ee7028223a7ef2, type: 3}
@@ -5591,7 +5502,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5674,11 +5585,6 @@ PrefabInstance:
 --- !u!224 &3629783549193465903 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3964241220478960268, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
-  m_PrefabInstance: {fileID: 386259031362613923}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &3629783549193465900 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3964241220478960271, guid: de584728bf140ce4e91afab68de87bf3, type: 3}
   m_PrefabInstance: {fileID: 386259031362613923}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1706949703475846884
@@ -5906,7 +5812,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5982,11 +5888,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
---- !u!1 &1068815459606876822 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1407240184101039587, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
-  m_PrefabInstance: {fileID: 2112949648828088181}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &1068815459606876817 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1407240184101039588, guid: 7c6b980767e5d4843927c7dd4c13fb62, type: 3}
@@ -6531,7 +6432,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6612,11 +6513,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5952850310990763030, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
   m_PrefabInstance: {fileID: 4433098887223836215}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &8005502527238466082 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5952850310990763029, guid: 3afe4d1fd94845d4eb05212b545ef2e3, type: 3}
-  m_PrefabInstance: {fileID: 4433098887223836215}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4510639525382448898
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6638,7 +6534,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6714,11 +6610,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
---- !u!1 &8739912033568406618 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5175591515052858200, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
-  m_PrefabInstance: {fileID: 4510639525382448898}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8739912033568406619 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5175591515052858201, guid: 2c7f04adb1481144c937479808b97e9a, type: 3}
@@ -6843,7 +6734,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6923,11 +6814,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
---- !u!1 &1908135428853529909 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5817660897569141627, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
-  m_PrefabInstance: {fileID: 5388403929890360910}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &1908135428853529908 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5817660897569141626, guid: 869802038bbca6a43a497f898e64dc21, type: 3}
@@ -7130,7 +7016,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
       propertyPath: m_AnchorMax.x
@@ -7206,11 +7092,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
---- !u!1 &3919868333965691841 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8761894498351811927, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}
-  m_PrefabInstance: {fileID: 5764233571269494422}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &3919868333965691854 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8761894498351811928, guid: a0fb2e63135ad0f4fbea5877b66a7761, type: 3}

--- a/Assets/Prefabs/UI/MagicShieldUI.prefab
+++ b/Assets/Prefabs/UI/MagicShieldUI.prefab
@@ -120,7 +120,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 501849646207720296}
-  - {fileID: 2222201996363583337}
+  - {fileID: 2556781719154210105}
+  - {fileID: 6194492524521615725}
+  - {fileID: 7526843761625601128}
+  - {fileID: 4824683239311907492}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -202,51 +205,12 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!1 &6900393825410745516
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2222201996363583337}
-  m_Layer: 5
-  m_Name: SequenceArrows
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2222201996363583337
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6900393825410745516}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2556781719154210105}
-  - {fileID: 6194492524521615725}
-  - {fileID: 7526843761625601128}
-  - {fileID: 4824683239311907492}
-  m_Father: {fileID: 2100020779333497184}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1963702991577169831
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2222201996363583337}
+    m_TransformParent: {fileID: 2100020779333497184}
     m_Modifications:
     - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_Name
@@ -262,7 +226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_AnchorMax.x
@@ -348,7 +312,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2222201996363583337}
+    m_TransformParent: {fileID: 2100020779333497184}
     m_Modifications:
     - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_Name
@@ -364,7 +328,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_AnchorMax.x
@@ -450,7 +414,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2222201996363583337}
+    m_TransformParent: {fileID: 2100020779333497184}
     m_Modifications:
     - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_Name
@@ -466,7 +430,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_AnchorMax.x
@@ -552,7 +516,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2222201996363583337}
+    m_TransformParent: {fileID: 2100020779333497184}
     m_Modifications:
     - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_Name
@@ -568,7 +532,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Prefabs/UI/MagicShieldUI.prefab
+++ b/Assets/Prefabs/UI/MagicShieldUI.prefab
@@ -35,8 +35,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1.9999204, y: 58}
-  m_SizeDelta: {x: 1115.6, y: 600}
+  m_AnchoredPosition: {x: 1.9999204, y: 52.698395}
+  m_SizeDelta: {x: 1297.15, y: 621.2065}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4954218198009369655
 CanvasRenderer:
@@ -120,7 +120,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 501849646207720296}
-  - {fileID: 2556781719154210105}
+  - {fileID: 2222201996363583337}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -202,12 +202,153 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!1001 &5786917299289923318
+--- !u!1 &6900393825410745516
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2222201996363583337}
+  m_Layer: 5
+  m_Name: SequenceArrows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2222201996363583337
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6900393825410745516}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2556781719154210105}
+  - {fileID: 6194492524521615725}
+  - {fileID: 7526843761625601128}
+  - {fileID: 4824683239311907492}
+  m_Father: {fileID: 2100020779333497184}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1963702991577169831
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2100020779333497184}
+    m_TransformParent: {fileID: 2222201996363583337}
+    m_Modifications:
+    - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Name
+      value: ArrowUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 130
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+--- !u!224 &7526843761625601128 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+  m_PrefabInstance: {fileID: 1963702991577169831}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2793221137725086370
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2222201996363583337}
     m_Modifications:
     - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_Name
@@ -267,23 +408,227 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: -75
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 130
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+--- !u!224 &6194492524521615725 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+  m_PrefabInstance: {fileID: 2793221137725086370}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3584995229405327723
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2222201996363583337}
+    m_Modifications:
+    - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Name
+      value: ArrowUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 225
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 130
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+--- !u!224 &4824683239311907492 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+  m_PrefabInstance: {fileID: 3584995229405327723}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5786917299289923318
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2222201996363583337}
+    m_Modifications:
+    - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Name
+      value: ArrowUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -225
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 130
       objectReference: {fileID: 0}
     - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Prefabs/UI/MagicShieldUI.prefab
+++ b/Assets/Prefabs/UI/MagicShieldUI.prefab
@@ -101,7 +101,6 @@ GameObject:
   - component: {fileID: 5838998639540139683}
   - component: {fileID: 8165783088095122994}
   - component: {fileID: 4973333442264879111}
-  - component: {fileID: 1436964509635950353}
   m_Layer: 5
   m_Name: MagicShieldUI
   m_TagString: Untagged
@@ -203,22 +202,6 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!114 &1436964509635950353
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6128566196424625912}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 044a99fc19b8b2f419d37fec7cab92f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  Slider: {fileID: 0}
-  HitArea: {fileID: 0}
-  StartPosition: {fileID: 0}
-  EndPosition: {fileID: 0}
 --- !u!1001 &5786917299289923318
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/MagicShieldUI.prefab
+++ b/Assets/Prefabs/UI/MagicShieldUI.prefab
@@ -1,0 +1,323 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5545480392332551288
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 501849646207720296}
+  - component: {fileID: 4954218198009369655}
+  - component: {fileID: 7580816570968500308}
+  - component: {fileID: 6963152623863777316}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &501849646207720296
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5545480392332551288}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
+  m_LocalScale: {x: 0.49999994, y: 0.49999994, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2100020779333497184}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1.9999204, y: 58}
+  m_SizeDelta: {x: 1115.6, y: 600}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4954218198009369655
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5545480392332551288}
+  m_CullTransparentMesh: 0
+--- !u!114 &7580816570968500308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5545480392332551288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!225 &6963152623863777316
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5545480392332551288}
+  m_Enabled: 1
+  m_Alpha: 0.49
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!1 &6128566196424625912
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100020779333497184}
+  - component: {fileID: 71796279272386620}
+  - component: {fileID: 5838998639540139683}
+  - component: {fileID: 8165783088095122994}
+  - component: {fileID: 4973333442264879111}
+  - component: {fileID: 1436964509635950353}
+  m_Layer: 5
+  m_Name: MagicShieldUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2100020779333497184
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128566196424625912}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 150.80608}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 501849646207720296}
+  - {fileID: 2556781719154210105}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2667, y: -110.65701}
+  m_SizeDelta: {x: 800, y: 600}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &71796279272386620
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128566196424625912}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &5838998639540139683
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128566196424625912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &8165783088095122994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128566196424625912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!225 &4973333442264879111
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128566196424625912}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &1436964509635950353
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6128566196424625912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 044a99fc19b8b2f419d37fec7cab92f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Slider: {fileID: 0}
+  HitArea: {fileID: 0}
+  StartPosition: {fileID: 0}
+  EndPosition: {fileID: 0}
+--- !u!1001 &5786917299289923318
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2100020779333497184}
+    m_Modifications:
+    - target: {fileID: 4905322366084376216, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Name
+      value: ArrowUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+--- !u!224 &2556781719154210105 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8301473261680274383, guid: 9eef64837d1e03a4cbb0a90c0eacdf10, type: 3}
+  m_PrefabInstance: {fileID: 5786917299289923318}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/UI/MagicShieldUI.prefab.meta
+++ b/Assets/Prefabs/UI/MagicShieldUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32fa5399bbdb9f0429d6bd40c2437bd2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -123,6 +123,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &32680 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6900393825410745516, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4697854
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11086,6 +11091,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7870359103648208777, guid: 7d69d0de1e40fda4e94be6819589947c, type: 3}
   m_PrefabInstance: {fileID: 7870359103265332102}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &800808777 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7120392636200631354, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &804032799
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13492,6 +13502,11 @@ Transform:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6543156113162692069, guid: ed91cc94734486443822a93acc4b9f01, type: 3}
   m_PrefabInstance: {fileID: 959502088}
+  m_PrefabAsset: {fileID: 0}
+--- !u!223 &963489079 stripped
+Canvas:
+  m_CorrespondingSourceObject: {fileID: 71796279272386620, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &963614063 stripped
 Transform:
@@ -17461,6 +17476,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6703086825455112006, guid: 738f97bd4edc08f46bf8c18eefe14908, type: 3}
   m_PrefabInstance: {fileID: 1171937727}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1172084726 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6868919363738065215, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1172087606
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20981,6 +21001,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6703086825455112006, guid: 738f97bd4edc08f46bf8c18eefe14908, type: 3}
   m_PrefabInstance: {fileID: 1374784921}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1374925346 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8490202947707230195, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1376808090
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -24189,6 +24214,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc9d22b5a5ea75f4f92451464d260bb7, type: 3}
+--- !u!1 &1658335840 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1467177511099168878, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1665661991 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6917805810791803028, guid: e266ca512c90051488aae56f02220f95, type: 3}
@@ -25395,6 +25425,34 @@ PrefabInstance:
       propertyPath: CandyCornCost
       value: 6
       objectReference: {fileID: 0}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: Arrows.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: MagicShieldCanvas
+      value: 
+      objectReference: {fileID: 963489079}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: SequenceArrowsGroup
+      value: 
+      objectReference: {fileID: 32680}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: Arrows.Array.data[0]
+      value: 
+      objectReference: {fileID: 1658335840}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: Arrows.Array.data[1]
+      value: 
+      objectReference: {fileID: 800808777}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: Arrows.Array.data[2]
+      value: 
+      objectReference: {fileID: 1172084726}
+    - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
+      propertyPath: Arrows.Array.data[3]
+      value: 
+      objectReference: {fileID: 1374925346}
     - target: {fileID: 2249674856687288453, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: playOnAwake
       value: 0
@@ -34996,6 +35054,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5838998639540139683, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_PresetInfoIsWorld
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6128566196424625912, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -2175,6 +2175,7 @@ RectTransform:
   - {fileID: 1558627560}
   - {fileID: 688253520}
   - {fileID: 920638877022153858}
+  - {fileID: 3344147706551358312}
   - {fileID: 1821511601}
   - {fileID: 2114283916}
   - {fileID: 2127111520}
@@ -8053,7 +8054,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7562228704362287581, guid: c14777a1972fc454992cf3e1cbdf8ac4, type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 7562228704362287581, guid: c14777a1972fc454992cf3e1cbdf8ac4, type: 3}
       propertyPath: m_AnchorMax.x
@@ -11611,7 +11612,7 @@ RectTransform:
   - {fileID: 1528823091}
   - {fileID: 1912185239}
   m_Father: {fileID: 230488909}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -31151,7 +31152,7 @@ Transform:
   m_LocalScale: {x: 0.6216006, y: 0.6216006, z: 0.6216006}
   m_Children: []
   m_Father: {fileID: 230488909}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2114283917
 MonoBehaviour:
@@ -33398,7 +33399,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1412053045929535380, guid: 2a6f00fe8866c984d928839e0271065a, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 1412053045929535380, guid: 2a6f00fe8866c984d928839e0271065a, type: 3}
       propertyPath: m_AnchorMax.x
@@ -34806,6 +34807,124 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1001 &3344147706551358311
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 230488909}
+    m_Modifications:
+    - target: {fileID: 1436964509635950353, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: Slider
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1436964509635950353, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: HitArea
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1436964509635950353, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: EndPosition
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1436964509635950353, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: StartPosition
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 150.80608
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 2667
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -110.65701
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6128566196424625912, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_Name
+      value: MagicShieldUI
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+--- !u!224 &3344147706551358312 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2100020779333497184, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+  m_PrefabInstance: {fileID: 3344147706551358311}
+  m_PrefabAsset: {fileID: 0}
 --- !u!33 &3416314287817670673
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -34950,7 +35069,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3531370939039482235, guid: af2a679cf5f6aec40890eb694eedad7f, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3531370939039482235, guid: af2a679cf5f6aec40890eb694eedad7f, type: 3}
       propertyPath: m_AnchorMax.x
@@ -38309,7 +38428,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8046737922919254993, guid: 245aafa1479104646bf1da999c5534b7, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 8046737922919254993, guid: 245aafa1479104646bf1da999c5534b7, type: 3}
       propertyPath: m_AnchorMax.x
@@ -38727,7 +38846,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8647470681806588950, guid: 6e8d3d96e4265d1439b4b796ef5982e3, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 8647470681806588950, guid: 6e8d3d96e4265d1439b4b796ef5982e3, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -123,11 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &32680 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6900393825410745516, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
-  m_PrefabInstance: {fileID: 3344147706551358311}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4697854
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -25436,7 +25431,7 @@ PrefabInstance:
     - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: SequenceArrowsGroup
       value: 
-      objectReference: {fileID: 32680}
+      objectReference: {fileID: 0}
     - target: {fileID: 2121341942659208810, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: Arrows.Array.data[0]
       value: 
@@ -34956,6 +34951,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 230488909}
     m_Modifications:
+    - target: {fileID: 501849646207720296, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 411.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 501849646207720296, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1436964509635950353, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
       propertyPath: Slider
       value: 
@@ -35056,6 +35059,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2556781719154210105, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4824683239311907492, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5838998639540139683, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
       propertyPath: m_PresetInfoIsWorld
       value: 0
@@ -35063,6 +35074,14 @@ PrefabInstance:
     - target: {fileID: 6128566196424625912, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
       propertyPath: m_Name
       value: MagicShieldUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 6194492524521615725, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526843761625601128, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 32fa5399bbdb9f0429d6bd40c2437bd2, type: 3}

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -703,11 +703,6 @@ Transform:
   m_Father: {fileID: 1105241855}
   m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &109940638 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3753020584209137767, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!82 &112464731 stripped
 AudioSource:
   m_CorrespondingSourceObject: {fileID: 3066114474422231529, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
@@ -1082,11 +1077,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3f3c20174392b84e83f9fce2e3b3a88, type: 3}
---- !u!1 &132188414 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5929867499229330490, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &136827527
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3279,11 +3269,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &321858756 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8005502527238466082, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &324050010 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6917805810791803028, guid: e266ca512c90051488aae56f02220f95, type: 3}
@@ -4070,11 +4055,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6335011000921784638, guid: fe42edcfbdb76aa42a5348388cd15cae, type: 3}
   m_PrefabInstance: {fileID: 1152316310}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &364133028 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 32015637468423594, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &366875913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4678,11 +4658,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
---- !u!1 &384013933 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4825868979387892557, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &384051825 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 734441219931439786, guid: 4f0c7afaa234f534b9fd84602339e0d7, type: 3}
@@ -5839,11 +5814,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2512415628385283932, guid: 70f690fbeaffa6e40b8cac39b7a74930, type: 3}
   m_PrefabInstance: {fileID: 458819014}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &461824891 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1908135428853529909, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &463244669
 GameObject:
   m_ObjectHideFlags: 0
@@ -6734,11 +6704,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
---- !u!1 &543285215 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3390780154999267369, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &549389646 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5803857789881976723, guid: dc9d22b5a5ea75f4f92451464d260bb7, type: 3}
@@ -7234,11 +7199,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a15e28ca3de0d294c9ead2b941259811, type: 3}
---- !u!1 &568309657 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6808847620924505044, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &572391929
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9206,11 +9166,6 @@ GameObject:
 --- !u!223 &678811462 stripped
 Canvas:
   m_CorrespondingSourceObject: {fileID: 4802617604654684682, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &682262480 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2831729533487336412, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
   m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &688253520 stripped
@@ -11370,11 +11325,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1412053047067180842, guid: 2a6f00fe8866c984d928839e0271065a, type: 3}
   m_PrefabInstance: {fileID: 1412053047331350565}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &810528942 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3629783549193465900, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &814285573
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11792,11 +11742,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &839379891 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3919868333965691841, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &840943368 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1831109336940026764, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
@@ -13117,11 +13062,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5732796609668156327, guid: a6def71e6d682ec4f8a0a6f642e75760, type: 3}
   m_PrefabInstance: {fileID: 927056731}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &928893288 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8739912033568406618, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &930261985
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13777,11 +13717,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
---- !u!1 &969122570 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1297265046394155879, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &972318231 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7636163635222842936, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
@@ -15354,11 +15289,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7636163635222842936, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
   m_PrefabInstance: {fileID: 1528482637}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1065758139 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2725620080624364059, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1066785948
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15651,31 +15581,31 @@ PrefabInstance:
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[0]
       value: 
-      objectReference: {fileID: 839379891}
+      objectReference: {fileID: 5650117169560658715}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[1]
       value: 
-      objectReference: {fileID: 1197243705}
+      objectReference: {fileID: 5650117169560658714}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[2]
       value: 
-      objectReference: {fileID: 928893288}
+      objectReference: {fileID: 5650117169560658713}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[3]
       value: 
-      objectReference: {fileID: 384013933}
+      objectReference: {fileID: 5650117169560658712}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[4]
       value: 
-      objectReference: {fileID: 810528942}
+      objectReference: {fileID: 5650117169560658711}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[5]
       value: 
-      objectReference: {fileID: 321858756}
+      objectReference: {fileID: 5650117169560658710}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientTypes.Array.data[6]
       value: 
-      objectReference: {fileID: 461824891}
+      objectReference: {fileID: 5650117169560658709}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: ConfectionMixVfxVerticalOffset
       value: 5
@@ -15687,51 +15617,51 @@ PrefabInstance:
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[0]
       value: 
-      objectReference: {fileID: 1065758139}
+      objectReference: {fileID: 5650117169560658708}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[1]
       value: 
-      objectReference: {fileID: 543285215}
+      objectReference: {fileID: 5650117169560658707}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[2]
       value: 
-      objectReference: {fileID: 1146893711}
+      objectReference: {fileID: 5650117169560658706}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[3]
       value: 
-      objectReference: {fileID: 568309657}
+      objectReference: {fileID: 5650117169560658705}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[4]
       value: 
-      objectReference: {fileID: 364133028}
+      objectReference: {fileID: 5650117169560658704}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[5]
       value: 
-      objectReference: {fileID: 1208687788}
+      objectReference: {fileID: 5650117169560658703}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[6]
       value: 
-      objectReference: {fileID: 2118321824}
+      objectReference: {fileID: 5650117169560658702}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[7]
       value: 
-      objectReference: {fileID: 2029094312}
+      objectReference: {fileID: 5650117169560658701}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[8]
       value: 
-      objectReference: {fileID: 969122570}
+      objectReference: {fileID: 5650117169560658700}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[9]
       value: 
-      objectReference: {fileID: 109940638}
+      objectReference: {fileID: 5650117169560658699}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[10]
       value: 
-      objectReference: {fileID: 682262480}
+      objectReference: {fileID: 5650117169560658698}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: IngredientSpawnLocations.Array.data[11]
       value: 
-      objectReference: {fileID: 132188414}
+      objectReference: {fileID: 5650117169560658697}
     - target: {fileID: 445950430552367694, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: MaxHealthPoints
       value: 300
@@ -16864,11 +16794,6 @@ Transform:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1878579944486917886, guid: f7d0dfae34d21a54e9b70029ef3b38a3, type: 3}
   m_PrefabInstance: {fileID: 1141096055}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1146893711 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5744601557947030412, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1151826415
 PrefabInstance:
@@ -18123,11 +18048,6 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!1 &1197243705 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1068815459606876822, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1198445206
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18479,11 +18399,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 8002685612168256424, guid: b2353d5ef1033ce4da623b3aa7dc01b7, type: 3}
   m_PrefabInstance: {fileID: 1208120815}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1208687788 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6368295264227912360, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1211210832
 PrefabInstance:
@@ -30024,11 +29939,6 @@ Transform:
   m_Father: {fileID: 1105241855}
   m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2029094312 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1531111683539428302, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2029178209
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -31428,11 +31338,6 @@ Transform:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2430083117438727187, guid: 7b3957bb1aac5a24798058681815ee41, type: 3}
   m_PrefabInstance: {fileID: 2117346706}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2118321824 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8026136126972687431, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
-  m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2121560197
 PrefabInstance:
@@ -36635,6 +36540,143 @@ AudioSource:
   m_CorrespondingSourceObject: {fileID: 4844819024866953055, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
   m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658697 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3077555402441148513, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658698 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4614577324672544047, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658699 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7777099977188230668, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658700 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7898608001803798589, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658701 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2861300414826752395, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658702 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7962404806484106671, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658703 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1600612634735457801, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658704 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4917653963586160251, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658705 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4834426053173541543, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658706 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3624136284522428375, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658707 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4716224448750590100, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5650117169560658708 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2480484824646191679, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5650117169560658709 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1908135428853529910, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5650117169560658710 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8005502527238466143, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5650117169560658711 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3629783549193465897, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5650117169560658712 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4825868979387892544, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5650117169560658713 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8739912033568406621, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5650117169560658714 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1068815459606876819, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5650117169560658715 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3919868333965691852, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54b916e7a7cb6fb4c9559e335a331abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &5680519943239370856
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -703,6 +703,11 @@ Transform:
   m_Father: {fileID: 1105241855}
   m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &109940638 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3753020584209137767, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!82 &112464731 stripped
 AudioSource:
   m_CorrespondingSourceObject: {fileID: 3066114474422231529, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
@@ -1077,6 +1082,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3f3c20174392b84e83f9fce2e3b3a88, type: 3}
+--- !u!1 &132188414 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5929867499229330490, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &136827527
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3269,6 +3279,11 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &321858756 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8005502527238466082, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &324050010 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6917805810791803028, guid: e266ca512c90051488aae56f02220f95, type: 3}
@@ -4055,6 +4070,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6335011000921784638, guid: fe42edcfbdb76aa42a5348388cd15cae, type: 3}
   m_PrefabInstance: {fileID: 1152316310}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &364133028 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 32015637468423594, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &366875913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4658,6 +4678,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
+--- !u!1 &384013933 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4825868979387892557, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &384051825 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 734441219931439786, guid: 4f0c7afaa234f534b9fd84602339e0d7, type: 3}
@@ -5814,6 +5839,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2512415628385283932, guid: 70f690fbeaffa6e40b8cac39b7a74930, type: 3}
   m_PrefabInstance: {fileID: 458819014}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &461824891 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1908135428853529909, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &463244669
 GameObject:
   m_ObjectHideFlags: 0
@@ -6704,6 +6734,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
+--- !u!1 &543285215 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3390780154999267369, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &549389646 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 5803857789881976723, guid: dc9d22b5a5ea75f4f92451464d260bb7, type: 3}
@@ -7199,6 +7234,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a15e28ca3de0d294c9ead2b941259811, type: 3}
+--- !u!1 &568309657 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6808847620924505044, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &572391929
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9166,6 +9206,11 @@ GameObject:
 --- !u!223 &678811462 stripped
 Canvas:
   m_CorrespondingSourceObject: {fileID: 4802617604654684682, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &682262480 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2831729533487336412, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
   m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &688253520 stripped
@@ -11325,6 +11370,11 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1412053047067180842, guid: 2a6f00fe8866c984d928839e0271065a, type: 3}
   m_PrefabInstance: {fileID: 1412053047331350565}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &810528942 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3629783549193465900, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &814285573
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11742,6 +11792,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &839379891 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3919868333965691841, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &840943368 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1831109336940026764, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
@@ -13062,6 +13117,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5732796609668156327, guid: a6def71e6d682ec4f8a0a6f642e75760, type: 3}
   m_PrefabInstance: {fileID: 927056731}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &928893288 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8739912033568406618, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &930261985
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -13717,6 +13777,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
+--- !u!1 &969122570 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1297265046394155879, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &972318231 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7636163635222842936, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
@@ -15289,6 +15354,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7636163635222842936, guid: c578357c78bc12e4da004ed5d239b42b, type: 3}
   m_PrefabInstance: {fileID: 1528482637}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1065758139 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2725620080624364059, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1066785948
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15575,9 +15645,93 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8007653149540863627}
     - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.size
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[0]
+      value: 
+      objectReference: {fileID: 839379891}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[1]
+      value: 
+      objectReference: {fileID: 1197243705}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[2]
+      value: 
+      objectReference: {fileID: 928893288}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[3]
+      value: 
+      objectReference: {fileID: 384013933}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[4]
+      value: 
+      objectReference: {fileID: 810528942}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[5]
+      value: 
+      objectReference: {fileID: 321858756}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientTypes.Array.data[6]
+      value: 
+      objectReference: {fileID: 461824891}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: ConfectionMixVfxVerticalOffset
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.size
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[0]
+      value: 
+      objectReference: {fileID: 1065758139}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[1]
+      value: 
+      objectReference: {fileID: 543285215}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[2]
+      value: 
+      objectReference: {fileID: 1146893711}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[3]
+      value: 
+      objectReference: {fileID: 568309657}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[4]
+      value: 
+      objectReference: {fileID: 364133028}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[5]
+      value: 
+      objectReference: {fileID: 1208687788}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[6]
+      value: 
+      objectReference: {fileID: 2118321824}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[7]
+      value: 
+      objectReference: {fileID: 2029094312}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[8]
+      value: 
+      objectReference: {fileID: 969122570}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[9]
+      value: 
+      objectReference: {fileID: 109940638}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[10]
+      value: 
+      objectReference: {fileID: 682262480}
+    - target: {fileID: 283313477316410387, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
+      propertyPath: IngredientSpawnLocations.Array.data[11]
+      value: 
+      objectReference: {fileID: 132188414}
     - target: {fileID: 445950430552367694, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: MaxHealthPoints
       value: 300
@@ -16710,6 +16864,11 @@ Transform:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1878579944486917886, guid: f7d0dfae34d21a54e9b70029ef3b38a3, type: 3}
   m_PrefabInstance: {fileID: 1141096055}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1146893711 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5744601557947030412, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1151826415
 PrefabInstance:
@@ -17964,6 +18123,11 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1 &1197243705 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1068815459606876822, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1198445206
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18315,6 +18479,11 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 8002685612168256424, guid: b2353d5ef1033ce4da623b3aa7dc01b7, type: 3}
   m_PrefabInstance: {fileID: 1208120815}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1208687788 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6368295264227912360, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1211210832
 PrefabInstance:
@@ -29855,6 +30024,11 @@ Transform:
   m_Father: {fileID: 1105241855}
   m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2029094312 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1531111683539428302, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2029178209
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -31254,6 +31428,11 @@ Transform:
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2430083117438727187, guid: 7b3957bb1aac5a24798058681815ee41, type: 3}
   m_PrefabInstance: {fileID: 2117346706}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2118321824 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8026136126972687431, guid: 0ae6fc049a2c5544c9c5fc228a8dbc0f, type: 3}
+  m_PrefabInstance: {fileID: 5650117169560658686}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2121560197
 PrefabInstance:

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -15758,15 +15758,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 360.2
+      value: 1288.21
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 217.31
+      value: 211.29
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 462.9
+      value: 324.3
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalRotation.w
@@ -25518,15 +25518,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 371.76
+      value: 1299.77
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 215.9
+      value: 209.87999
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 454.75003
+      value: 316.15002
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scripts/Combat/Abilities/Confection.cs
+++ b/Assets/Scripts/Combat/Abilities/Confection.cs
@@ -49,10 +49,10 @@ public class Confection : Ability
     private ConfectionVfx ConfectionMixVfx;
     private GameObject Target;
     [SerializeField] private float ConfectionMixVfxVerticalOffset;
-    [SerializeField] private GameObject[] IngredientTypes;
-    [SerializeField] private GameObject[] IngredientSpawnLocations;
+    [SerializeField] private DragAndDrop[] IngredientTypes;
+    [SerializeField] private Transform[] IngredientSpawnLocations;
     private bool[] IsIngredientReserved;
-    private readonly Stack<GameObject> IngredientStack = new Stack<GameObject>();
+    private readonly Stack<DragAndDrop> IngredientStack = new Stack<DragAndDrop>();
 
     public new void Start()
     {
@@ -292,12 +292,7 @@ public class Confection : Ability
         { 
             Debug.Log("Canvas is Null in StartBrewPhase()"); 
         }
-
-        foreach (var ingredient in IngredientTypes)
-        {
-            ingredient.GetComponent<DragAndDrop>().InitializeStartingPosition();
-        }
-
+        
         RandomizeIngredientSpawns();
 
         Timer.StartTimer(BrewDuration);
@@ -322,6 +317,7 @@ public class Confection : Ability
 
                 ingredient.GetComponent<RectTransform>().position = 
                     IngredientSpawnLocations[randomPosition].GetComponent<RectTransform>().position;
+                ingredient.InitializeStartingPosition();
                 IsIngredientReserved[randomPosition] = true;
             }
         }
@@ -383,10 +379,23 @@ public class Confection : Ability
     {
         foreach (var ingredient in IngredientTypes)
         {
-            ingredient.SetActive(true);
-            ingredient.GetComponent<DragAndDrop>().ResetPosition();
+            ingredient.ResetPosition();
+            ingredient.gameObject.SetActive(false);
         }
 
+        for (var i = 0; i < IngredientSpawnLocations.Length; ++i)
+        {
+            if (IsIngredientReserved[i])
+            {
+                IsIngredientReserved[i] = false;
+            }
+        }
+
+        if (IngredientStack.Count > 0)
+        {
+            IngredientStack.Clear();
+        }
+        
         SweetsDropped = 0;
         RotsDropped = 0;
         CookingPot.ResetConfectionValues();

--- a/Assets/Scripts/Combat/Abilities/DragAndDrop.cs
+++ b/Assets/Scripts/Combat/Abilities/DragAndDrop.cs
@@ -9,6 +9,9 @@ public class DragAndDrop : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndD
     private RectTransform RectTransform;
     private CanvasGroup CanvasGroup;
     private Canvas Canvas;
+    public enum DropType { None, Bullet, Sweet, Veggie}
+    [SerializeField] private DropType DropTypeEnum;
+    public DropType DropTypeEnumPublic => DropTypeEnum;
 
     private void Start()
     {
@@ -19,13 +22,13 @@ public class DragAndDrop : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndD
 
     public void InitializeStartingPosition()
     {
-        OriginalPos = this.gameObject.transform.position;
+        OriginalPos = transform.position;
     }
 
     public void ResetPosition()
     {
-        Debug.Log("ResetPosition");
-        this.gameObject.transform.position = OriginalPos;
+        Debug.Log($"ResetPosition for DragAndDrop {gameObject.name}");
+        gameObject.transform.position = OriginalPos;
         GetComponent<CanvasGroup>().blocksRaycasts = true;
         IsInside = false;
     }
@@ -38,9 +41,10 @@ public class DragAndDrop : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndD
     public void OnDrag(PointerEventData eventData)
     {
         // TODO: possibly snap back to original position ?
-        if (!IsInside) {
+        if (!IsInside)
+        {
             Vector2 delta = eventData.delta;
-            this.gameObject.transform.position += new Vector3(delta.x, delta.y, 0);
+            gameObject.transform.position += new Vector3(delta.x, delta.y, 0.0f);
         }
     }
 

--- a/Assets/Scripts/Combat/Abilities/ItemsBeingDropped.cs
+++ b/Assets/Scripts/Combat/Abilities/ItemsBeingDropped.cs
@@ -31,22 +31,20 @@ public class ItemsBeingDropped : MonoBehaviour, IDropHandler
 
     private void HandleDroppedItems(PointerEventData eventData)
     {
-        if (!eventData.pointerDrag.GetComponent<DragAndDrop>().GetIsInside())
+        if (eventData.pointerDrag.TryGetComponent<DragAndDrop>(out var dropItem) && !dropItem.GetIsInside())
         {
-            if(eventData.pointerDrag.name == "Sweet")
+            if(dropItem.DropTypeEnumPublic == DragAndDrop.DropType.Sweet)
             {
                 SweetsDropped++;
                 Debug.Log("Sweets Dropped:" + SweetsDropped);
-                eventData.pointerDrag.GetComponent<DragAndDrop>().SetIsInside(true);
-                eventData.pointerDrag.SetActive(false);
             }
 
-            else if(eventData.pointerDrag.name == "Rotten")
+            else if(dropItem.DropTypeEnumPublic == DragAndDrop.DropType.Veggie)
             {
                 RotsDropped++;
-                eventData.pointerDrag.GetComponent<DragAndDrop>().SetIsInside(true);
-                eventData.pointerDrag.SetActive(false);
             }
+            eventData.pointerDrag.GetComponent<DragAndDrop>().SetIsInside(true);
+            eventData.pointerDrag.SetActive(false);
         }
     }
 

--- a/Assets/Scripts/Combat/Abilities/PimpkinHead.cs
+++ b/Assets/Scripts/Combat/Abilities/PimpkinHead.cs
@@ -43,8 +43,8 @@ public class PimpkinHead : MonoBehaviour
     {
         Debug.Log("Hit pimpkin!!!!!");
         PipmkinDeathSource.Play();
-        gameObject.SetActive(false);
         IsHit = true;
+        gameObject.SetActive(false);
     }
 
     public void ResetPimpkinValues()

--- a/Assets/Scripts/Combat/Abilities/Revolver.cs
+++ b/Assets/Scripts/Combat/Abilities/Revolver.cs
@@ -52,6 +52,8 @@ public class Revolver : Ability
     private Transform RevolverNozzle;
     [SerializeField] private ParticleSystem Gunshot;
 
+    private bool isCoroutineWaiting = false;
+
 
     public new void Start()
     {
@@ -234,17 +236,21 @@ public class Revolver : Ability
                 ShootSource.Play();
             }
         }
-
         else
         {
             Debug.Log("Ending Shooting Phase");
-            EndShootingPhase();
+            if (!isCoroutineWaiting)
+            {
+                StartCoroutine(EndShootingPhase());
+            }
         }
 
     }
 
-    private void EndShootingPhase()
+    private IEnumerator EndShootingPhase()
     {
+        isCoroutineWaiting = true;
+        yield return new WaitForSeconds(0.5f);
         Debug.Log("Ending Ability");
 
         Timer.ResetTimer();
@@ -252,6 +258,7 @@ public class Revolver : Ability
         Debug.Log($"Total Pimpkins Hit: {TotalPimpkinsHit}");
         CalculateRevolverDamage();
         EndAbility();
+        isCoroutineWaiting = false;
     }
 
     private void ResetShootingValues()

--- a/Assets/Scripts/Combat/Abilities/ThunderStorm.cs
+++ b/Assets/Scripts/Combat/Abilities/ThunderStorm.cs
@@ -29,7 +29,7 @@ public class ThunderStorm : Ability
     [Header("Damage Parameters")]
     private int Presses;
     private readonly float ThunderStormScale = 0.04f;
-    private readonly float ThunderStormHeight = 7f;
+    private readonly float ThunderStormHeight = 8f;
     private readonly float ThunderCloudDuration = 5.0f;
     private readonly int ThunderCloudMinimumDamage = 15;
     private readonly int ThunderCloudMaximumDamage = 30;
@@ -120,7 +120,8 @@ public class ThunderStorm : Ability
         {
             CurrentPhase = ThunderstormPhase.Inactive;
 
-            if (CurrentThunderStrike < TotalThunderStrikes)
+            var possibleVictims = Array.FindAll(TargetedCombatants, combatant => combatant.GetComponent<Combatant>().IsAlive).Length;
+            if (CurrentThunderStrike < TotalThunderStrikes && possibleVictims > 0)
                 Invoke(nameof(NewThunderStrike), Random.Range(StrikeTimeInterval, 1.5f * StrikeTimeInterval));
             else
                 EndAbility();


### PR DESCRIPTION
- Added new mini game for magic shield
- Improved thunderstorm particle systems (cloud and lightning)
- Randomized confection ingredient placement in brew canvas
- Corrected missing last pimpkin head bullet hit for total damage calculation
- Corrected thunderstorm strikes targeting last dead pimpkin