### PR TITLE
Implement checkpoint system on player battle loss

### DIFF
--- a/Assets/Prefabs/Animation/GanielCostAC.controller
+++ b/Assets/Prefabs/Animation/GanielCostAC.controller
@@ -213,7 +213,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: -5316290765938078582}
-    m_Position: {x: 383.59167, y: 79.332184, z: 0}
+    m_Position: {x: 380, y: 80, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2225571510011517476}
     m_Position: {x: 380, y: 270, z: 0}

--- a/Assets/Prefabs/Characters/Ganiel.prefab
+++ b/Assets/Prefabs/Characters/Ganiel.prefab
@@ -1423,6 +1423,7 @@ MonoBehaviour:
   RotationSpeed: 360
   FollowDistance: 5
   CatchUpSpeed: 15
+  PlayerCollider: {fileID: 1068027122880330472}
 --- !u!114 &5565676062077663811
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1456,6 +1457,7 @@ MonoBehaviour:
   HurtSound: {fileID: 6949792102507138324}
   IsAlive: 1
   Animator: {fileID: 4885474363960887048}
+  DeathAudioSource: {fileID: 0}
   isBoss: 0
   costume: {fileID: 5921640282964799081}
 --- !u!136 &5232389671787067547

--- a/Assets/Prefabs/Characters/Sield.prefab
+++ b/Assets/Prefabs/Characters/Sield.prefab
@@ -1589,6 +1589,7 @@ MonoBehaviour:
   RotationSpeed: 360
   FollowDistance: 5
   CatchUpSpeed: 15
+  PlayerCollider: {fileID: 7874035099135784521}
 --- !u!114 &603280033588285928
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1622,6 +1623,7 @@ MonoBehaviour:
   HurtSound: {fileID: 782069733137587307}
   IsAlive: 1
   Animator: {fileID: 7367481652005828946}
+  DeathAudioSource: {fileID: 0}
   isBoss: 0
   costume: {fileID: 6912708998622068073}
 --- !u!136 &7874035099135784521

--- a/Assets/Prefabs/Combat/Combat Zone Base.prefab
+++ b/Assets/Prefabs/Combat/Combat Zone Base.prefab
@@ -1,5 +1,35 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6097417480455113907
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7874941042238849913}
+  m_Layer: 0
+  m_Name: CheckpointReset
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7874941042238849913
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6097417480455113907}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6700999341351202736}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6700999341351202740
 GameObject:
   m_ObjectHideFlags: 0
@@ -31,6 +61,7 @@ Transform:
   - {fileID: 3781572183662706031}
   - {fileID: 250865318076906829}
   - {fileID: 3873982918217795705}
+  - {fileID: 7874941042238849913}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -259,9 +290,17 @@ PrefabInstance:
       value: Combat Area
       objectReference: {fileID: 0}
     - target: {fileID: 6187274634682210007, guid: 5118471d90d0c424a9d09e8bf42ccaaf, type: 3}
+      propertyPath: CombatCollider
+      value: 
+      objectReference: {fileID: 6553119747406950473}
+    - target: {fileID: 6187274634682210007, guid: 5118471d90d0c424a9d09e8bf42ccaaf, type: 3}
       propertyPath: Enemies.Array.data[1]
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 6187274634682210007, guid: 5118471d90d0c424a9d09e8bf42ccaaf, type: 3}
+      propertyPath: CheckpointResetPosition
+      value: 
+      objectReference: {fileID: 7874941042238849913}
     - target: {fileID: 6187274634682210007, guid: 5118471d90d0c424a9d09e8bf42ccaaf, type: 3}
       propertyPath: EnemyPositions.Array.data[0]
       value: 
@@ -339,5 +378,10 @@ PrefabInstance:
 --- !u!4 &7056465320621897019 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6675716342669569934, guid: 5118471d90d0c424a9d09e8bf42ccaaf, type: 3}
+  m_PrefabInstance: {fileID: 4416185663105342133}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &6553119747406950473 stripped
+BoxCollider:
+  m_CorrespondingSourceObject: {fileID: 7473770615092603644, guid: 5118471d90d0c424a9d09e8bf42ccaaf, type: 3}
   m_PrefabInstance: {fileID: 4416185663105342133}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/UI/BattleVictoryBanner.prefab
+++ b/Assets/Prefabs/UI/BattleVictoryBanner.prefab
@@ -165,7 +165,7 @@ GameObject:
   - component: {fileID: 8647470681048651240}
   - component: {fileID: 8647470681048651247}
   m_Layer: 5
-  m_Name: Sentence
+  m_Name: CandyText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -187,7 +187,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -20.6, y: -16.900007}
+  m_AnchoredPosition: {x: -22.6, y: -16.900007}
   m_SizeDelta: {x: 189.48648, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8647470681048651240
@@ -218,7 +218,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: You got 100
+  m_text: Returned 100
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 93416bd1cd4c44c488f1de547868f752, type: 2}
   m_sharedMaterial: {fileID: 883901213575197334, guid: 93416bd1cd4c44c488f1de547868f752, type: 2}
@@ -252,7 +252,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 4
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -281,7 +281,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 1
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: -37.531494, y: 0, z: 0, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -321,7 +321,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 91.77003, y: -16.9}
+  m_AnchoredPosition: {x: 99.7, y: -16.9}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8647470681069012460
@@ -374,7 +374,7 @@ GameObject:
   - component: {fileID: 8647470681582747653}
   - component: {fileID: 8647470681582747652}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: TitleText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -8112,6 +8112,18 @@ PrefabInstance:
       propertyPath: Enemies.Array.data[0]
       value: 
       objectReference: {fileID: 368549088}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2051
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.931
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
 --- !u!4 &612271929 stripped
@@ -15962,7 +15974,7 @@ PrefabInstance:
       objectReference: {fileID: 5650117169560658697}
     - target: {fileID: 445950430552367694, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: MaxHealthPoints
-      value: 300
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1070968612503828290, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -16046,15 +16058,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 91.536
+      value: 377.75
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 199.763
+      value: 207.014
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 420.782
+      value: 618.80005
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalRotation.w
@@ -19448,7 +19460,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 557d2fb70bb24e646a85c8c198366bc1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TotalCandyCorn: 0
+  TotalCandyCorn: 20
   CandyCornCollectedAnimator: {fileID: 1816936315}
   CandyCornCollectedTextField: {fileID: 1816936311}
 --- !u!1001 &1253561414
@@ -19566,6 +19578,18 @@ PrefabInstance:
       propertyPath: Enemies.Array.data[0]
       value: 
       objectReference: {fileID: 673437148}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.3881
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.5424
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.4697
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
 --- !u!4 &1253561415 stripped
@@ -25755,15 +25779,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 96.656
+      value: 382.87
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 199.739
+      value: 206.99
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 416.75198
+      value: 614.77
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalRotation.w
@@ -25795,7 +25819,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8454097014992259087, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: MaxHealthPoints
-      value: 300
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8454097014992259087, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: HealthBarUIPanel
@@ -32394,6 +32418,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalScale.z
       value: 1.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.311
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.1206
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.746
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]

--- a/Assets/Scenes/Main_Scene.unity
+++ b/Assets/Scenes/Main_Scene.unity
@@ -5025,6 +5025,18 @@ PrefabInstance:
       propertyPath: Enemies.Array.data[0]
       value: 
       objectReference: {fileID: 2121560199}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.428
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.3312
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.978
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
 --- !u!4 &385527556 stripped
@@ -6164,6 +6176,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.626
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.453
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.1947
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.624
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]
@@ -8114,15 +8138,15 @@ PrefabInstance:
       objectReference: {fileID: 368549088}
     - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.06
+      value: -0.242
       objectReference: {fileID: 0}
     - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.2051
+      value: -0.315
       objectReference: {fileID: 0}
     - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.931
+      value: -5.476
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
@@ -8696,6 +8720,18 @@ PrefabInstance:
     - target: {fileID: 2873965626528658329, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.228
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.4475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.1665
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.816
       objectReference: {fileID: 0}
     - target: {fileID: 3243505776043423838, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
       propertyPath: Enemies.Array.data[0]
@@ -9932,6 +9968,18 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0.288
       objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.894
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2703
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.735
+      objectReference: {fileID: 0}
     - target: {fileID: 3243505776043423838, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
       propertyPath: Enemies.Array.data[0]
       value: 
@@ -10804,6 +10852,18 @@ PrefabInstance:
       propertyPath: Enemies.Array.data[0]
       value: 
       objectReference: {fileID: 2117346708}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.027
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.137
+      objectReference: {fileID: 0}
+    - target: {fileID: 7874941042238849913, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.019
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ff38e3e739b1404409dd82ff06c9f469, type: 3}
 --- !u!4 &763820853 stripped
@@ -12156,6 +12216,18 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0.74
       objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2199
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.698
+      objectReference: {fileID: 0}
     - target: {fileID: 3243505776043423838, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
       propertyPath: Enemies.Array.data[0]
       value: 
@@ -12555,6 +12627,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.202
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.156
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.709
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]
@@ -13882,6 +13966,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 1.642
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.4033
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.809
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]
@@ -15974,7 +16070,7 @@ PrefabInstance:
       objectReference: {fileID: 5650117169560658697}
     - target: {fileID: 445950430552367694, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: MaxHealthPoints
-      value: 10
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 1070968612503828290, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -16058,15 +16154,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 377.75
+      value: 91.68
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 207.014
+      value: 200.1
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 618.80005
+      value: 420.25
       objectReference: {fileID: 0}
     - target: {fileID: 5226253233174535603, guid: ec49ba67b66451342aacf76b17feebaa, type: 3}
       propertyPath: m_LocalRotation.w
@@ -16669,6 +16765,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalScale.x
       value: 3.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.2776
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.1227
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.355
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]
@@ -18578,6 +18686,18 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.602
       objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.238
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.166
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.835
+      objectReference: {fileID: 0}
     - target: {fileID: 3243505776043423838, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
       propertyPath: Enemies.Array.data[0]
       value: 
@@ -19460,7 +19580,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 557d2fb70bb24e646a85c8c198366bc1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TotalCandyCorn: 20
+  TotalCandyCorn: 0
   CandyCornCollectedAnimator: {fileID: 1816936315}
   CandyCornCollectedTextField: {fileID: 1816936311}
 --- !u!1001 &1253561414
@@ -25507,6 +25627,18 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0.184
       objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.401
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944996264621766469, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.376
+      objectReference: {fileID: 0}
     - target: {fileID: 3243505776043423838, guid: 1cdff3e909802d7459165aab27df9d07, type: 3}
       propertyPath: Enemies.Array.data[0]
       value: 
@@ -25779,15 +25911,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 382.87
+      value: 96.80001
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 206.99
+      value: 200.076
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 614.77
+      value: 416.21997
       objectReference: {fileID: 0}
     - target: {fileID: 7887312764890489834, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: m_LocalRotation.w
@@ -25819,7 +25951,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8454097014992259087, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: MaxHealthPoints
-      value: 10
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 8454097014992259087, guid: 5ef547a01e5efa34d82a65ab26cfe4d2, type: 3}
       propertyPath: HealthBarUIPanel
@@ -26210,6 +26342,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalScale.z
       value: 1.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.2145
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2243
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.786
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]
@@ -28982,6 +29126,18 @@ PrefabInstance:
     - target: {fileID: 6234478468744931377, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: m_LocalScale.x
       value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.508
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0819
+      objectReference: {fileID: 0}
+    - target: {fileID: 6494650085204401779, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.69
       objectReference: {fileID: 0}
     - target: {fileID: 6916443783815926120, guid: ec99cd52c802137439dd30358a539d6c, type: 3}
       propertyPath: Enemies.Array.data[0]

--- a/Assets/Scripts/Combat/Combantants/AllyCombatant.cs
+++ b/Assets/Scripts/Combat/Combantants/AllyCombatant.cs
@@ -8,22 +8,23 @@ public class AllyCombatant : Combatant
 {
     [SerializeField] Costume costume;
 
-    new public void Start()
+    public new void Start()
     {
         base.Start();
 
         costume.DisplayAbilities(false);
     }
 
-    new public void Update()
+    public new void Update()
     {
         base.Update();
     }
 
-    new public void ExitCombat()
+    public new void ExitCombat()
     {
         base.ExitCombat();
         GetComponentInChildren<Costume>().DisplayAbilities(false);
+        Animator.Play("Base Layer.IdleWalk");
     }
 
     protected override void TakeTurnWhileDead()

--- a/Assets/Scripts/Combat/Combantants/Combatant.cs
+++ b/Assets/Scripts/Combat/Combantants/Combatant.cs
@@ -345,7 +345,6 @@ public abstract class Combatant : MonoBehaviour
     public void ResetPoints()
     {
         IsAlive = true;
-        Animator.Play("Base Layer.IdleWalk");
         CurrentHealthPoints = MaxHealthPoints;
         CurrentShieldPoints = 0;
         MaxShieldPoints = 0;

--- a/Assets/Scripts/Combat/Combantants/EnemyCombatant.cs
+++ b/Assets/Scripts/Combat/Combantants/EnemyCombatant.cs
@@ -30,7 +30,12 @@ public class EnemyCombatant : Combatant
         base.Update();
     }
 
-
+    public new void ExitCombat()
+    {
+        base.ExitCombat();
+        Animator.Play("Base Layer.Idle");
+    }
+    
     protected override void TakeTurnWhileDead()
     {
         // TODO add some dead idling animation? 

--- a/Assets/Scripts/Combat/CombatSystem.cs
+++ b/Assets/Scripts/Combat/CombatSystem.cs
@@ -32,6 +32,8 @@ public class CombatSystem : MonoBehaviour
     private CandyCornManager CandyCornManager;
     private int TotalCandyReward;
     private GameObject BattleVictoryBanner;
+    private TextMeshProUGUI BattleBannerTitleText;
+    private TextMeshProUGUI BattleBannerText;
     private int InitialCandyCornNumber;
 
     void Start()
@@ -41,6 +43,9 @@ public class CombatSystem : MonoBehaviour
         #endif
 
         BattleVictoryBanner = GameObject.Find("BattleVictoryBanner");
+        // Hacky way. CHANGE PREFAB NAMES BEFORE CHANGING THIS!
+        BattleBannerTitleText = BattleVictoryBanner.transform.Find("Image").GetComponentInChildren<TextMeshProUGUI>();
+        BattleBannerText = BattleVictoryBanner.transform.Find("Panel").GetComponentInChildren<TextMeshProUGUI>();
         BattleVictoryBanner.GetComponent<CanvasGroup>().alpha = 0f;
         MainCamera = GameObject.FindGameObjectWithTag("MainCamera");
         CameraRig = MainCamera.GetComponent<CameraRig>();
@@ -100,9 +105,7 @@ public class CombatSystem : MonoBehaviour
         // If it's not the boss that died, return to normal gameplay win
         if (!IsBossDead)
         {
-            BattleVictoryBanner.GetComponentInChildren<TMP_Text>().text = "You got " + TotalCandyReward;
-
-            StartCoroutine(ShowVictoryBanner());
+            StartCoroutine(ShowVictoryBanner(true, TotalCandyReward));
 
             CurrentCombatZone.GetComponent<CombatZone>().DestroyCombatZone();
 
@@ -168,6 +171,7 @@ public class CombatSystem : MonoBehaviour
             CandyCornManager.RemoveCandyCorn(-candyDifference); // double negate value to properly subtract in function
         }
         CandyCornManager.AddCandyCorn(InitialCandyCornNumber - CandyCornManager.GetTotalCandyCorn());
+        StartCoroutine(ShowVictoryBanner(false, Mathf.Abs(candyDifference)));
         InitialCandyCornNumber = 0;
         CurrentCombatZone = null;
 
@@ -258,8 +262,19 @@ public class CombatSystem : MonoBehaviour
         Combatants[CurrentCombatantTurn - 1].GetComponent<Combatant>().StartTurn();
     }
 
-    private IEnumerator ShowVictoryBanner()
+    private IEnumerator ShowVictoryBanner(bool isVictory, int candyDisplay)
     {
+        if (isVictory)
+        {
+            BattleBannerTitleText.text = $"Victory!";
+            BattleBannerText.text = $"You won {candyDisplay}";
+        }
+        else
+        {
+            BattleBannerTitleText.text = $"Defeat!";
+            BattleBannerText.text = $"Returned {candyDisplay}";
+        }
+        
         BattleVictoryBanner.GetComponent<CanvasGroup>().alpha = 1f;
         yield return new WaitForSeconds(2);
         BattleVictoryBanner.GetComponent<CanvasGroup>().alpha = 0f;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -7,6 +7,7 @@ public class Player : MonoBehaviour
 {
     [SerializeField]
     private bool IsMainPlayer = false;
+    public bool GetIsMainPlayer => IsMainPlayer;
     [SerializeField]
     private float MovementSpeed = 1f;
     [SerializeField]
@@ -15,6 +16,7 @@ public class Player : MonoBehaviour
     private float FollowDistance = 5f;
     [SerializeField]
     private float CatchUpSpeed = 2f; // ? TODO
+    [SerializeField] private Collider PlayerCollider;
 
     private Vector3 TargetPosition;
     private Quaternion TargetRotation;
@@ -128,5 +130,10 @@ public class Player : MonoBehaviour
         GetComponent<CharacterController>().enabled = false;
         GetComponent<Player>().enabled = false;
         IsMovementDisabled = true;
+    }
+
+    public void SetColliderVisibility(bool isActive)
+    {
+        PlayerCollider.enabled = isActive;
     }
 }


### PR DESCRIPTION
- Every time the allies loose a battle, they reset to a near checkpoint as well as their candy corns, health, etc.
- Even the enemies are reset to how they were before the battle.
- The battle victory banner now displays info on ally defeat as well.